### PR TITLE
Initialize class members in the constructor

### DIFF
--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -1,6 +1,12 @@
 #include <DS18B20.h>
 
-DS18B20::DS18B20(uint8_t pin) : oneWire(OneWire(pin)) {
+DS18B20::DS18B20(uint8_t pin) :
+    oneWire(OneWire(pin)),
+    numberOfDevices(0),
+    globalResolution(0),
+    selectedResolution(0),
+    selectedPowerMode(0)
+{
     resetSearch();
     sendCommand(SKIP_ROM, READ_POWER_SUPPLY);
     globalPowerMode = oneWire.read_bit();


### PR DESCRIPTION
Previously some class members were used before initialization, leading to undefined behavior when the class object was created on the stack. For example `getNumberOfDevices()` returned random junk.