### PR TITLE
default value for switch ( avoid WARN return-type)

### DIFF
--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -103,6 +103,8 @@ uint8_t DS18B20::getResolution() {
             return 11;
         case RES_12_BIT:
             return 12;
+        default:
+            return -1; //Avoid warning [-Wreturn-type]
     }
 }
 


### PR DESCRIPTION
In VSCode & PlatformIO I get the warning: for not having a default return value.