### PR TITLE
Add a possibility to handle multiple sensors efficiently

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2024 Sikach Bogdan
 Copyright (c) 2013 Mathias Munk Hansen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/README.md
+++ b/README.md
@@ -1,51 +1,6 @@
 # DS18B20 #
 
-Arduino library for the Maxim Integrated DS18B20 1-Wire temperature sensor. This library is very simple and intuitive to use, and supports auto-discovering sensors with an optional high/low condition or manually addressing individual sensors.
+This is a fork from the original repo: https://github.com/matmunk/DS18B20
 
-For example, we can get the temperature from every sensor on the wire with just a few lines of code:
-
-```
-#include <DS18B20.h>
-
-DS18B20 ds(2);
-
-void setup() {
-  Serial.begin(9600);
-}
-
-void loop() {
-  while (ds.selectNext()) {
-    Serial.println(ds.getTempC());
-  }
-}
-```
-
-See the included [examples](/examples/) for more.
-
-## Installation ##
-
-This library uses the OneWire library, so you will need to have this installed. Install it using the Library Manager in the Arduino IDE or download the latest release from [GitHub](https://github.com/PaulStoffregen/OneWire).
-
-In the **OneWire.h** file set `ONEWIRE_SEARCH` to 0 since the search functionality is also implemented in this library (don't do this if you need the search functionality for other 1-Wire devices). CRC must be enabled (choose whichever algorithm you prefer). This may save some space on your Arduino.
-
-## Wiring the DS18B20 ##
-The resistor shown in all the circuit diagrams is 4.7k Ohm pullup resistor.
-
-### External Power Mode ###
-
-#### Single ####
-![A single externally powered DS18B20](/extras/single_external.png)
-
-#### Multiple ####
-![Multiple externally powered DS18B20s](/extras/multiple_external.png)
-
-### Parasitic Power Mode ###
-
-#### Single ####
-![A single parasite powered DS18B20](/extras/single_parasite.png)
-
-#### Multiple ####
-![Multiple parasite powered DS18B20s](/extras/multiple_parasite.png)
-
-### Mixed Power Mode ###
-![Mixed mode DS18B20s](/extras/mixed_mode.png)
+The only difference is the ability to broadcast the conversion command
+without delaying the microcontroller. See the [MultipleBroadcast](examples/MultipleBroadcast) example.

--- a/examples/MultipleBroadcast/MultipleBroadcast.ino
+++ b/examples/MultipleBroadcast/MultipleBroadcast.ino
@@ -1,0 +1,164 @@
+#include <DS18B20.h>
+
+/* Configuration (start) */
+const uint8_t CFG_N_DEVICES = 17; // number of sensors in the system
+const uint8_t CFG_BUS_PIN   = 2;  // 1-Wire data pin
+
+/* The INTERVAL value MUST be consistent with the sensor conversion time (see the documentation)
+ Sensor conversion time table:
+   --------------------------------
+   Resolution           | Time
+   --------------------------------
+   12 bit (default)     | 750ms
+   11 bit               | 750ms / 2
+   10 bit               | 750ms / 4
+   9  bit               | 750ms / 8
+   --------------------------------
+*/
+const uint16_t CFG_INTERVAL = 25000;// f [Hz] = (16000000 / ((CFG INTERVAL + 1) * 1024)) = 15625 / (CFG_INTERVAL + 1)
+
+/* A NOTE ON THE RESOLUTION SETTING:
+
+ It seems fake sensors (as we probably have here)
+ don't allow to change the resolution so
+ you are able to use only the default one --- 12 bits.
+*/
+
+/* Printing format
+ a) If defined printing format is the following  (4-column temperature table):
+
+    temp  temp  temp  temp
+    ...
+    temp  temp  temp  temp
+
+ useful when debugging.
+
+ b) If undefined (e.g. commented) printing format is a list of 3 fields:
+
+    temp
+    resolution
+    address
+
+    temp
+    resolution
+    address
+
+    ...
+ */
+#define CFG_TABLE_VIEW
+/* Configuration (end) */
+
+/* SensorData (start) */
+struct SensorData
+{
+  uint8_t resolution;
+  float   temperature;
+  uint8_t address[8];
+
+  void print();
+  void reset();
+};
+
+void SensorData::print()
+{
+  Serial.print( "Address: " );
+  for( uint8_t i = 0; i < 8; ++i )
+  {
+    Serial.print( address[i], HEX );
+  }
+  Serial.println();
+  Serial.print( "Resolution: " );
+  Serial.println( resolution );
+  Serial.print( "Temperature: " );
+  Serial.println( temperature );
+}
+
+void SensorData::reset()
+{
+  temperature = 0.0;
+  resolution  = 0;
+  for( uint8_t i = 0; i < 8; ++i )
+  {
+    address[i] = 0;
+  }
+}
+/* SensorData (end) */
+
+/* Global (start) */
+DS18B20 sensor( CFG_BUS_PIN );
+SensorData sensors[CFG_N_DEVICES];
+volatile bool updateSensors = true;
+/* Global (end) */
+
+void timerSetup()
+{
+  noInterrupts();
+
+  TCCR1A = TCCR1B = TCNT1 = 0;
+  OCR1A = CFG_INTERVAL;
+  TCCR1B |= (1 << WGM12);
+  TCCR1B |= (1 << CS12) | (1 << CS10);
+  TIMSK1 |= (1 << OCIE1A);
+
+  interrupts();
+}
+
+void setup()
+{
+  Serial.begin( 115200 );
+
+  pinMode( CFG_BUS_PIN, INPUT );
+
+  timerSetup();
+}
+
+void loop()
+{
+  if( not updateSensors )
+  {
+    return;
+  }
+
+  noInterrupts();
+  
+  updateSensors = false;
+  
+  for( uint8_t i = 0; i < CFG_N_DEVICES; ++i )
+  {
+    sensors[i].reset();
+  }
+
+  for( uint8_t i = 0; sensor.selectNext() and (i < CFG_N_DEVICES); ++i )
+  {
+    sensors[i].temperature = sensor.getTempCFromScratchPad();
+    sensors[i].resolution  = sensor.getResolution();
+    sensor.getAddress( sensors[i].address );
+  }
+
+#ifdef CFG_TABLE_VIEW
+    Serial.print("============================");
+    for( uint8_t i = 0; i < CFG_N_DEVICES; ++i )
+    {
+      if( i % 4 == 0 ) Serial.println();
+      Serial.print( sensors[i].temperature );
+      Serial.print( "  " );
+    }
+    Serial.println();
+    Serial.print("============================");
+    Serial.println();
+#else
+    for( uint8_t i = 0; i < CFG_N_DEVICES; ++i )
+    {
+      sensors[i].print();
+      Serial.println();
+    }
+#endif
+
+  interrupts();
+}
+
+ISR(TIMER1_COMPA_vect)
+{
+  sensor.doConversion();
+  updateSensors = true;
+}

--- a/examples/MultipleBroadcast/MultipleBroadcast.ino
+++ b/examples/MultipleBroadcast/MultipleBroadcast.ino
@@ -91,7 +91,7 @@ SensorData sensors[CFG_N_DEVICES];
 
 void setup()
 {
-  Serial.begin( 115200 );
+  Serial.begin( 9600 );
 }
 
 unsigned long now = 0;

--- a/library.properties
+++ b/library.properties
@@ -1,11 +1,11 @@
 name=DS18B20
-version=1.0.0
-author=Mathias Munk Hansen
-maintainer=Mathias Munk Hansen <matmunk@gmail.com>
+version=1.0.1
+author=Mathias Munk Hansen, Sikach Bogdan
+maintainer=Mathias Munk Hansen <matmunk@gmail.com>, Sikach Bogdan <paradox1859@gmail.com>
 sentence=Arduino library for the Maxim Integrated DS18B20 1-Wire temperature sensor.
 paragraph=This library is very simple and intuitive to use, and supports auto-discovering sensors with an optional high/low condition or manually addressing individual sensors.
 category=Sensors
-url=https://github.com/matmunk/DS18B20
+url=https://github.com/LRDPRDX/DS18B20
 architectures=*
 includes=DS18B20.h
 depends=OneWire

--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -148,9 +148,9 @@ void DS18B20::getAddress(uint8_t address[]) {
     memcpy(address, selectedAddress, 8);
 }
 
-void DS18B20::doConversion() {
+void DS18B20::doConversion( bool wait ) {
     sendCommand(SKIP_ROM, CONVERT_T, !globalPowerMode);
-    delayForConversion(globalResolution, globalPowerMode);
+    delayForConversion(globalResolution, globalPowerMode, wait);
 }
 
 uint8_t DS18B20::getNumberOfDevices() {
@@ -350,10 +350,10 @@ uint8_t DS18B20::isConnected(uint8_t address[]) {
     return 1;
 }
 
-void DS18B20::delayForConversion(uint8_t resolution, uint8_t powerMode) {
+void DS18B20::delayForConversion(uint8_t resolution, uint8_t powerMode, bool wait ) {
     if (powerMode) {
         while (!oneWire.read_bit());
-    } else {
+    } else if (wait) {
         switch (resolution) {
             case 9:
                 delay(CONV_TIME_9_BIT);

--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -63,6 +63,11 @@ void DS18B20::resetSearch() {
 float DS18B20::getTempC() {
     sendCommand(MATCH_ROM, CONVERT_T, !selectedPowerMode);
     delayForConversion(selectedResolution, selectedPowerMode);
+    return getTempCFromScratchPad();
+}
+
+float DS18B20::getTempCFromScratchPad()
+{
     readScratchpad();
     uint8_t lsb = selectedScratchpad[TEMP_LSB];
     uint8_t msb = selectedScratchpad[TEMP_MSB];

--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -351,6 +351,9 @@ uint8_t DS18B20::isConnected(uint8_t address[]) {
 }
 
 void DS18B20::delayForConversion(uint8_t resolution, uint8_t powerMode, bool wait ) {
+    if( not wait ) {
+        return;
+    }
     if (powerMode) {
         while (!oneWire.read_bit());
     } else if (wait) {

--- a/src/DS18B20.h
+++ b/src/DS18B20.h
@@ -50,7 +50,7 @@ class DS18B20 {
         uint8_t getPowerMode();
         uint8_t getFamilyCode();
         void getAddress(uint8_t address[]);
-        void doConversion();
+        void doConversion( bool wait = true);
         uint8_t getNumberOfDevices();
         uint8_t hasAlarm();
         void setAlarms(int8_t alarmLow, int8_t alarmHigh);
@@ -81,7 +81,7 @@ class DS18B20 {
         uint8_t sendCommand(uint8_t romCommand, uint8_t functionCommand, uint8_t power = 0);
         uint8_t oneWireSearch(uint8_t romCommand);
         uint8_t isConnected(uint8_t address[]);
-        void delayForConversion(uint8_t resolution, uint8_t powerMode);
+        void delayForConversion(uint8_t resolution, uint8_t powerMode, bool wait = true);
 };
 
 #endif

--- a/src/DS18B20.h
+++ b/src/DS18B20.h
@@ -43,6 +43,7 @@ class DS18B20 {
         uint8_t selectNextAlarm();
         void resetSearch();
         float getTempC();
+        float getTempCFromScratchPad();
         float getTempF();
         uint8_t getResolution();
         void setResolution(uint8_t resolution);


### PR DESCRIPTION
As I can see the current version handles multiple sensors in series:

```
for s in sensors
  do conversion
  read the temperature
```

so entire delay is proportional to the number of sensors in the system.

This commit allows you to read multiple sensors much faster:

```
do conversion
for s in sensors
  read the temperature
```

I've tested it with 17 sensors in the system.