### PR TITLE
Allow getting temperature without implicit conversion request

### DIFF
--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -63,6 +63,10 @@ void DS18B20::resetSearch() {
 float DS18B20::getTempC() {
     sendCommand(MATCH_ROM, CONVERT_T, !selectedPowerMode);
     delayForConversion(selectedResolution, selectedPowerMode);
+    return readTempC();
+}
+
+float DS18B20::readTempC() {
     readScratchpad();
     uint8_t lsb = selectedScratchpad[TEMP_LSB];
     uint8_t msb = selectedScratchpad[TEMP_MSB];
@@ -91,6 +95,10 @@ float DS18B20::getTempC() {
 
 float DS18B20::getTempF() {
     return getTempC() * 1.8 + 32;
+}
+
+float DS18B20::readTempF() {
+    return readTempC() * 1.8 + 32;
 }
 
 uint8_t DS18B20::getResolution() {

--- a/src/DS18B20.h
+++ b/src/DS18B20.h
@@ -44,6 +44,8 @@ class DS18B20 {
         void resetSearch();
         float getTempC();
         float getTempF();
+        float readTempC();
+        float readTempF();
         uint8_t getResolution();
         void setResolution(uint8_t resolution);
         uint8_t getPowerMode();


### PR DESCRIPTION
Break out temperature functions so that temperature can be obtained without implicit conversion requests on the bus.

the doConversion() function can then be used to signal to all devices to start a conversion, before calling the readTemp*() functions.